### PR TITLE
Handle folders

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,5 +1,7 @@
+import { get_folders } from "src/utils/get-folders";
 import { get_project, logout, sleep, import_file } from "../utils";
 import { get_files } from "../utils/get-files";
+import { import_folder } from "src/utils/import_folder";
 
 const OPTIONS = {
   source_url: "",
@@ -36,6 +38,16 @@ async function sync(options = OPTIONS) {
       .then((r) => r.data.data);
 
     destination.folder_id = folder.id;
+  }
+
+  console.log("Starting importing folders (ordered by ID)...");
+  for await (const chunk of get_folders(source)) {
+    await Promise.all(
+      chunk.map((folder) => import_folder(folder, source, destination))
+    );
+
+    console.log(`Imported ${chunk[0].id}, 9+`);
+    await sleep(wait_between_chunks);
   }
 
   console.log("Starting importing files (ordered by ID)...");

--- a/src/types/DirectusFile.d.ts
+++ b/src/types/DirectusFile.d.ts
@@ -4,6 +4,7 @@ declare global {
     filename_download: string;
     filesize: string;
     type: string;
+    folder: string;
   }
 }
 

--- a/src/types/DirectusFolder.d.ts
+++ b/src/types/DirectusFolder.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  interface DirectusFolder {
+    id: string;
+    name: string;
+    parent: string;
+  }
+}
+
+export {};

--- a/src/utils/get-folders.ts
+++ b/src/utils/get-folders.ts
@@ -1,15 +1,15 @@
 import type { AxiosResponse } from "axios";
 
-export async function* get_files(project: Project) {
-  let response: AxiosResponse<DirectusFile[]>;
+export async function* get_folders(project: Project) {
+  let response: AxiosResponse<DirectusFolder[]>;
   const MAX = 10;
   let page = 1;
 
   do {
     response = await project.axios
-      .get("/files", {
+      .get("/folders", {
         params: {
-          fields: ["id", "filename_download", "filesize", "type", "folder"],
+          fields: ["id", "name", "parent"],
           limit: MAX,
           sort: "id",
           page: page++,

--- a/src/utils/import_file.ts
+++ b/src/utils/import_file.ts
@@ -31,7 +31,7 @@ export async function import_file(
         id: file.id,
         type: file.type,
         filename_download: file.filename_download,
-        folder: destination.folder_id,
+        folder: file.folder,
       },
     },
     { headers: { Authorization: `Bearer ${destination.token}` } }

--- a/src/utils/import_folder.ts
+++ b/src/utils/import_folder.ts
@@ -1,0 +1,32 @@
+export async function import_folder(
+  folder: DirectusFolder,
+  source: Project,
+  destination: Project
+) {
+  const exists = await destination.axios
+    .get("/folders", {
+      params: {
+        fields: ["id"],
+        filter: {
+          id: { _eq: folder.id },
+        },
+      },
+    })
+    .then((r) => {
+      return (r.data?.data?.length ?? 0) > 0;
+    });
+
+  if (exists) return;
+
+  const imported = await destination.axios.post(
+    "/folders",
+    {
+      id: folder.id,
+      name: folder.name,
+      parent: folder.parent ? folder.parent : destination.folder_id,
+    },
+    { headers: { Authorization: `Bearer ${destination.token}` } }
+  );
+
+  return imported.data.data;
+}


### PR DESCRIPTION
# Motivation
Current approach only imports files to a folder `Imported (YYYY-MM-dd HH:mm)`
While this might work well for cases where folders are not needed, there's other cases where folders are required.

# Solution
In order to solve this, a root folder `Imported (YYYY-MM-dd HH:mm)` will still be created, but all the folders from source will be imported to destination. Then, each file is imported to the right folder in destination as it is in source.